### PR TITLE
Adds support for remote serial ports.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,9 @@ Command Line Tool
       -h, --help            show this help message and exit
       -v                    be more verbose
       -d DEVICE, --device DEVICE
+                            set local device e.g. '/dev/ttyUSB0' or
+                            set remote device e.g. 'rfc2217://[IP]:[PORT]'
+                            default: '/dev/ttyUSB0'
       -f FREQUENCY_RFM1     set the frequency for RFM1
       -F FREQUENCY_RFM2     set the frequency for RFM2
       -t TOGGLE_INTERVAL_RFM1
@@ -80,6 +83,25 @@ then the tool will print the defined names
     id=16 t=18.700000 h=60 nbat=0 name=Livingroom
     id=0 t=17.400000 h=65 nbat=0 name=Kitchen
 
+Using remote serial port with ser2net
+-------------------------------------
+
+You can also use ser2net to connect to a remote JeeLink Adapter. This can be useful, if you use
+a docker container or if you can not attach a JeeLink adapter to your host running pylacrosse. On your
+remote device install ser2net and add the following line to your ser2net.conf:
+
+.. code :: shell
+
+    20001:telnet:0:/dev/ttyUSB0:57600 remctl banner
+
+Restart the ser2net daemon and connect to your remote host using pylacrosse command line tool:
+
+.. code :: shell
+
+    # pylacrosse -d rfc2217://[REMOTE_IP]]:20001 scan
+    id=40 t=16.000000 h=69 nbat=0 name=Bedroom
+    id=16 t=18.700000 h=60 nbat=0 name=Livingroom
+    id=0 t=17.400000 h=65 nbat=0 name=Kitchen
 
 .. _Jeelink: https://www.digitalsmarties.net/products/jeelink
 .. _sketch: https://svn.fhem.de/trac/browser/trunk/fhem/contrib/arduino/36_LaCrosse-LaCrosseITPlusReader.zip

--- a/pylacrosse/cli_tool.py
+++ b/pylacrosse/cli_tool.py
@@ -19,7 +19,6 @@ import argparse
 import codecs
 import logging
 import os
-import pprint
 import time
 try:
     from ConfigParser import (SafeConfigParser, NoOptionError)
@@ -92,10 +91,13 @@ def led(lacrosse, config, args):
     lacrosse.led_config(state)
 
 def main(args=None):
-    parser = argparse.ArgumentParser('LaCrosse sensor CLI tool.')
+    parser = argparse.ArgumentParser('LaCrosse sensor CLI tool.', formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('-v', action='store_true', dest='verbose',
             help='be more verbose')
     parser.add_argument('-d', '--device', type=str, dest='device',
+            help='set local device e.g. \'{0}\' or\n'
+                 'set remote device e.g. \'rfc2217://[IP]:[PORT]\'\n'
+                 'default: \'{0}\''.format(DEFAULT_DEVICE),
             default=DEFAULT_DEVICE)
     parser.add_argument('-f', type=str, dest='frequency_rfm1',
             help='set the frequency for RFM1')

--- a/pylacrosse/lacrosse.py
+++ b/pylacrosse/lacrosse.py
@@ -19,7 +19,6 @@ from __future__ import unicode_literals
 import logging
 import re
 import threading
-from serial import Serial
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,7 +54,7 @@ class LaCrosse(object):
         self._port = port
         self._baud = baud
         self._timeout = timeout
-        self._serial = Serial()
+        self._serial = SerialPortFactory().create_serial_port(port)
         self._callback_data = None
 
     def open(self):
@@ -241,3 +240,13 @@ class LaCrosseSensor(object):
     def __repr__(self):
         return "id=%d t=%f h=%d nbat=%d" % \
             (self.sensorid, self.temperature, self.humidity, self.new_battery)
+
+
+class SerialPortFactory(object):
+    def create_serial_port(self, port):
+        if port.startswith("rfc2217://"):
+            from serial.rfc2217 import Serial
+            return Serial()
+        else:
+            from serial import Serial
+            return Serial()


### PR DESCRIPTION
Hi, it would be great to have remote serial ports also included in this library. With this PR i added a factory that checks the prefix of the port property. If the port starts with "rfc2217://" it will use the RFC2217 implementation of serial else the serial port implementation. I have testet this with ser2net and the following config line:

`2000:telnet:0:/dev/ttyS0:9600 remctl banner`

You can then run the following command from the client command line:

`pylacrosse -d rfc2217://192.168.0.1:20001 scan`

I am not a python developer. Feel free to change this code :-)