### PR TITLE
Do not install tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name = name,
         long_description = readme,
         author = 'Heiko Thiery',
         author_email = 'heiko.thiery@gmail.com',
-        packages = find_packages(),
+        packages = find_packages(exclude=('tests', 'tests.*')),
         url = 'http://github.com/hthiery/python-lacrosse',
         license = 'LGPLv2+',
         classifiers = [


### PR DESCRIPTION
Installing tests is generally not desirable in the first place, but particularly not in the global top level `tests` package.

`tests.*` is to catch possible subpackages added in the future.