### PR TITLE
add sleep to _write_cmd

### DIFF
--- a/pylacrosse/lacrosse.py
+++ b/pylacrosse/lacrosse.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 import logging
 import re
 import threading
+import time
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,6 +79,8 @@ class LaCrosse(object):
     def _write_cmd(self, cmd):
         """Write a cmd."""
         self._serial.write(cmd.encode())
+        """ensure there is enough time between commands"""
+        time.sleep(0.5)
 
     @staticmethod
     def _parse_info(line):

--- a/pylacrosse/lacrosse.py
+++ b/pylacrosse/lacrosse.py
@@ -77,10 +77,11 @@ class LaCrosse(object):
         self._start_worker()
 
     def _write_cmd(self, cmd):
-        """Write a cmd."""
-        self._serial.write(cmd.encode())
         """ensure there is enough time between commands"""
         time.sleep(0.5)
+        """Write a cmd."""
+        self._serial.write(cmd.encode())
+
 
     @staticmethod
     def _parse_info(line):


### PR DESCRIPTION
Without the sleep the commands are sent too fast to the USB-Device, so map and toggle won't work, neither from cli nor Homeassistant.