### PR TITLE
Migrate tests to nose

### DIFF
--- a/tests/test_lacrosse.py
+++ b/tests/test_lacrosse.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 import time
+import pytest
 
-from nose.tools import eq_, raises
 from mock import MagicMock
 
 from pylacrosse import (LaCrosse, LaCrosseSensor)
@@ -49,25 +49,25 @@ class TestLacrosse(object):
         time.sleep(0.01)
         l._stop_worker()
 
-        eq_(mock_cb_1.call_count, 1)
-        eq_(mock_cb_2.call_count, 2)
+        assert mock_cb_1.call_count == 1
+        assert mock_cb_2.call_count == 2
 
     def test_get_info(self):
         info = LaCrosse._parse_info('[LaCrosseITPlusReader.10.1s (RFM12B f:0 r:17241)]')
-        eq_(info['name'], 'LaCrosseITPlusReader')
-        eq_(info['version'], '10.1s')
+        assert info['name'] == 'LaCrosseITPlusReader'
+        assert info['version'] == '10.1s'
 
         info = LaCrosse._parse_info('[LaCrosseITPlusReader.10.1s (RFM12B f:0 r:17241)]')
-        eq_(info['rfm1name'], 'RFM12B')
-        eq_(info['rfm1frequency'], '0')
-        eq_(info['rfm1datarate'], '17241')
+        assert info['rfm1name'] == 'RFM12B'
+        assert info['rfm1frequency'] == '0'
+        assert info['rfm1datarate'] == '17241'
 
         info = LaCrosse._parse_info('[LaCrosseITPlusReader.10.1s (RFM12B f:0 t:10~3)]')
-        eq_(info['rfm1name'], 'RFM12B')
-        eq_(info['rfm1frequency'], '0')
-        eq_(info['rfm1datarate'], None)
-        eq_(info['rfm1toggleinterval'], '10')
-        eq_(info['rfm1togglemask'], '3')
+        assert info['rfm1name'] == 'RFM12B'
+        assert info['rfm1frequency'] == '0'
+        assert info['rfm1datarate'] == None
+        assert info['rfm1toggleinterval'] == '10'
+        assert info['rfm1togglemask'] == '3'
 
     def test_led_mode_state(self):
         mock = MagicMock()
@@ -99,15 +99,15 @@ class TestLacrosse(object):
         l.set_frequency(400, rfm=2)
         l._serial.write.assert_called_with(b'400F')
 
-    @raises(KeyError)
     def test_set_frequency_invalid_rfm(self):
         mock = MagicMock()
 
         l = LaCrosse('/dev/ttyTEST', 115200)
         l._serial.write = mock
 
-        l.set_frequency(500, rfm=3)
-        l._serial.write.assert_called_with(b'400f')
+        with pytest.raises(KeyError):
+            l.set_frequency(500, rfm=3)
+            l._serial.write.assert_called_with(b'400f')
 
     def test_set_datarate(self):
         mock = MagicMock()
@@ -161,9 +161,9 @@ class TestLaCrosseSensor(object):
 
     def test_init(self):
         s = LaCrosseSensor('OK 9 1 1 4 150 66')
-        eq_(s.sensorid, 1)
-        eq_(s.sensortype, 1)
-        eq_(s.temperature, 17.4)
-        eq_(s.humidity, 66)
-        eq_(s.new_battery, False)
-        eq_(s.low_battery, False)
+        assert s.sensorid == 1
+        assert s.sensortype == 1
+        assert s.temperature == 17.4
+        assert s.humidity == 66
+        assert not s.new_battery
+        assert not s.low_battery


### PR DESCRIPTION
Hi, [nixpkgs](https://github.com/NixOS/nixpkgs) (nixOS package repository) contributer here. `nose` is abandoned upstream, so [in a effort of cleanup](https://github.com/NixOS/nixpkgs/issues/326513), the following set of patches were made to your project. This migrate to pytest with is a widely used python testing library.

https://nose.readthedocs.io/en/latest/
> *Nose has been in maintenance mode for the past several years and will likely cease without a new person/team to take over maintainership. New projects should consider using [Nose2](https://github.com/nose-devs/nose2), [py.test](http://pytest.org/), or just plain unittest/unittest2.*